### PR TITLE
[Glad] Step 4 - 3 DB에 저장하기

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Stage 1: Build
+FROM openjdk:21-jdk-bullseye AS builder
+WORKDIR /home/gradle/project
+COPY . .
+RUN chmod +x ./gradlew && \
+    ./gradlew clean bootJar --no-daemon --stacktrace --info && \
+    ls -l build/libs/
+
+# Stage 2: Runtime
+FROM openjdk:21-jdk-bullseye
+WORKDIR /app
+COPY --from=builder /home/gradle/project/build/libs/codestagram-0.0.1-SNAPSHOT.jar app.jar
+
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -122,3 +122,7 @@
 
 - `UserRepository`를 사용하여 사용자 데이터를 저장
   - `save()` 메소드 사용
+
+### 배포
+
+https://port-0-be-spring-cafe-m8famrv1da7fb95d.sel4.cloudtype.app/

--- a/README.md
+++ b/README.md
@@ -93,3 +93,32 @@
 - `<input type="hidden" name="_method" value="PUT" />`을 사용하여 `PUT` method로 요청
 - Spring에서 `PUT` method를 사용하기 위해 `HiddenHttpMethodFilter`를 추가
   - `spring.mvc.hiddenmethod.filter.enabled=true` 추가
+
+## 3. DB에 저장하기
+
+### H2 DB 설정
+
+- Spring Data JPA를 사용하여 H2 DB를 사용
+- 의존성 추가
+
+### 게시글 데이터 저장
+
+- `ArticleRepository`를 사용하여 게시글 데이터를 저장
+- `Article` Entity에 `@Entity` 어노테이션 추가
+- `Article` Entity에 `@Id` 어노테이션 추가
+  - `PK`로 지정
+
+### 게시글 목록 구현
+
+- `ArticleRepository`를 사용하여 게시글 목록을 조회
+  - `findAll()` 메소드 사용
+
+### 상세보기 구현
+
+- `ArticleRepository`를 사용하여 게시글 상세보기 구현
+  - `findById()` 메소드 사용
+
+### 사용자 데이터 저장
+
+- `UserRepository`를 사용하여 사용자 데이터를 저장
+  - `save()` 메소드 사용

--- a/application.yaml
+++ b/application.yaml
@@ -1,0 +1,36 @@
+spring:
+  h2:
+    console:
+      enabled: true  # H2 Console을 사용할지 여부 (H2 Console은 H2 Database를 UI로 제공해주는 기능)
+      path: /h2-console  # H2 Console의 Path
+  # Database Setting Info (Database를 H2로 사용하기 위해 H2연결 정보 입력)
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: 'jdbc:h2:mem:test'
+    username: sa
+    password:
+  jpa:
+    generate-ddl: 'true'
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        format_sql: true
+        show_sql: true
+
+
+
+#spring:
+#  datasource:
+#    driver-class-name: org.h2.Driver
+#    url: 'jdbc:h2:mem:test'		# In-Memory Mode
+#    # url: 'jdbc:h2:~/test'		# Embedded Mode
+#    username: test
+#    password: test1234
+#
+#  h2:
+#    console:
+#      enabled: true
+#      path: /h2-console

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	// H2
+	runtimeOnly 'com.h2database:h2'
+	// JPA
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 }
 
 tasks.named('test') {

--- a/src/main/java/codesquad/codestagram/config/MvcConfig.java
+++ b/src/main/java/codesquad/codestagram/config/MvcConfig.java
@@ -11,7 +11,7 @@ public class MvcConfig implements WebMvcConfigurer {
     public void addViewControllers(ViewControllerRegistry registry) {
         registry.setOrder(Ordered.HIGHEST_PRECEDENCE);
 
-        registry.addViewController("/signup").setViewName("/user/form");
-        registry.addViewController("/write").setViewName("/article/form");
+        registry.addViewController("signup").setViewName("user/form");
+        registry.addViewController("write").setViewName("article/form");
     }
 }

--- a/src/main/java/codesquad/codestagram/domain/ViewController.java
+++ b/src/main/java/codesquad/codestagram/domain/ViewController.java
@@ -17,7 +17,7 @@ public class ViewController {
         this.articleRepository = articleRepository;
     }
 
-    @GetMapping("/")
+    @GetMapping("")
     public String index(Model model) {
         List<Article> articles = articleRepository.findAll();
         model.addAttribute("articles", articles);

--- a/src/main/java/codesquad/codestagram/domain/article/Article.java
+++ b/src/main/java/codesquad/codestagram/domain/article/Article.java
@@ -1,18 +1,27 @@
 package codesquad.codestagram.domain.article;
 
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "article")
 public class Article {
 
-    private final int id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
     private String title;
     private String content;
 
-    public Article(int id, String title, String content) {
+    public Article(Long id, String title, String content) {
         this.id = id;
         this.title = title;
         this.content = content;
     }
 
-    public int getId() {
+    public Article() {
+    }
+
+    public Long getId() {
         return id;
     }
 

--- a/src/main/java/codesquad/codestagram/domain/article/Article.java
+++ b/src/main/java/codesquad/codestagram/domain/article/Article.java
@@ -12,8 +12,7 @@ public class Article {
     private String title;
     private String content;
 
-    public Article(Long id, String title, String content) {
-        this.id = id;
+    public Article(String title, String content) {
         this.title = title;
         this.content = content;
     }

--- a/src/main/java/codesquad/codestagram/domain/article/ArticleController.java
+++ b/src/main/java/codesquad/codestagram/domain/article/ArticleController.java
@@ -20,7 +20,7 @@ public class ArticleController {
     public String addArticle(@RequestParam String title,
                              @RequestParam String content) {
 
-        int id = articleRepository.size() + 1;
+        long id = articleRepository.count() + 1;
         Article article = new Article(id, title, content);
         articleRepository.save(article);
 
@@ -28,7 +28,7 @@ public class ArticleController {
     }
 
     @GetMapping("{id}")
-    public String viewArticle(@PathVariable int id, Model model) {
+    public String viewArticle(@PathVariable Long id, Model model) {
         Optional<Article> article = articleRepository.findById(id);
 
         if (article.isEmpty()) {

--- a/src/main/java/codesquad/codestagram/domain/article/ArticleController.java
+++ b/src/main/java/codesquad/codestagram/domain/article/ArticleController.java
@@ -20,8 +20,7 @@ public class ArticleController {
     public String addArticle(@RequestParam String title,
                              @RequestParam String content) {
 
-        long id = articleRepository.count() + 1;
-        Article article = new Article(id, title, content);
+        Article article = new Article(title, content);
         articleRepository.save(article);
 
         return "redirect:/";

--- a/src/main/java/codesquad/codestagram/domain/article/ArticleRepository.java
+++ b/src/main/java/codesquad/codestagram/domain/article/ArticleRepository.java
@@ -1,35 +1,11 @@
 package codesquad.codestagram.domain.article;
 
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
 @Repository
-public class ArticleRepository {
-
-    private final List<Article> articles;
-
-    public ArticleRepository(List<Article> articles) {
-        this.articles = articles;
-    }
-
-    public List<Article> findAll() {
-        return articles;
-    }
-
-    public Optional<Article> findById(int id) {
-        return articles.stream()
-                .filter(article -> article.getId() == id)
-                .findFirst();
-    }
-
-    public void save(Article article) {
-        articles.add(article);
-    }
-
-    public int size() {
-        return articles.size();
-    }
-
+public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/src/main/java/codesquad/codestagram/domain/user/User.java
+++ b/src/main/java/codesquad/codestagram/domain/user/User.java
@@ -1,7 +1,14 @@
 package codesquad.codestagram.domain.user;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "users")
 public class User {
 
+    @Id
     private String id;
     private String password;
     private String name;
@@ -12,6 +19,9 @@ public class User {
         this.password = password;
         this.name = name;
         this.email = email;
+    }
+
+    public User() {
     }
 
     public String getId() {

--- a/src/main/java/codesquad/codestagram/domain/user/UserController.java
+++ b/src/main/java/codesquad/codestagram/domain/user/UserController.java
@@ -1,6 +1,7 @@
 package codesquad.codestagram.domain.user;
 
 import org.springframework.stereotype.Controller;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
@@ -64,6 +65,7 @@ public class UserController {
     }
 
     @PutMapping("{id}")
+    @Transactional
     public String updateUser(@PathVariable String id,
                              @RequestParam String email,
                              @RequestParam String name,

--- a/src/main/java/codesquad/codestagram/domain/user/UserController.java
+++ b/src/main/java/codesquad/codestagram/domain/user/UserController.java
@@ -33,7 +33,7 @@ public class UserController {
         List<User> users = userRepository.findAll();
         model.addAttribute("users", users);
 
-        return "/user/list";
+        return "user/list";
     }
 
     @GetMapping("{id}")
@@ -48,7 +48,7 @@ public class UserController {
 
         model.addAttribute("user", user);
 
-        return "/user/profile";
+        return "user/profile";
     }
 
     @GetMapping("{id}/form")
@@ -61,7 +61,7 @@ public class UserController {
 
         model.addAttribute("user", user);
 
-        return "/user/edit";
+        return "user/edit";
     }
 
     @PutMapping("{id}")

--- a/src/main/java/codesquad/codestagram/domain/user/UserRepository.java
+++ b/src/main/java/codesquad/codestagram/domain/user/UserRepository.java
@@ -1,36 +1,11 @@
 package codesquad.codestagram.domain.user;
 
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Repository
-public class UserRepository {
+public interface UserRepository extends JpaRepository<User, Long> {
 
-    private final List<User> users;
-
-    public UserRepository(List<User> users) {
-        this.users = users;
-    }
-
-    public void save(User user) {
-        users.add(user);
-    }
-
-    public List<User> findAll() {
-        return users;
-    }
-
-    public User findById(String id) {
-        return users.stream()
-                .filter(u -> u.getId().equals(id))
-                .findFirst()
-                .orElse(null);
-    }
-
-    public void delete(User user) {
-        users.remove(user);
-    }
+    User findById(String id);
 
 }

--- a/src/main/resources/templates/article/form.html
+++ b/src/main/resources/templates/article/form.html
@@ -9,7 +9,7 @@
     <div th:replace="~{nav.html}"></div>
     
     <div class="container mt-5">
-        <h2 class="mb-4">게시글 작성하기초</h2>
+        <h2 class="mb-4">게시글 작성하기</h2>
         
         <form th:action="@{/articles}" method="post">
             <div class="mb-3">


### PR DESCRIPTION
## 구현 내용

- H2 Database 연결
  - application.yaml -> h2, jpa datasource 설정

- `JPA Repository`를 상속받은 인터페이스로 수정
- `Article`
  - 게시글 데이터 DB 에 저장
  - `Article class` id 를 `PK`로 설정
- `User`
  - 유저 목록 DB에 저장
  - `User class` 유저 고유 Id 를 pk로 설정
  - 세부 내용을 `id`를 기준으로 받아옴
- 모든 데이터 조회를 H2에서 하게끔 설정

[배포 링크](https://port-0-be-spring-cafe-m8famrv1da7fb95d.sel4.cloudtype.app/)

## 고민 사항

- 로그인, 유저식별, 게시글 수정 및 삭제, 중복확인 등등 아직 구현이 안 된 부분이 많다.
- 배포시에 타임리프가 템플릿 경로를 찾을 때 앞에 `/`가 붙어있으면 찾지 못하는 문제가 있었는데 제거해줌으로서 해결했다

## 기타
