### PR TITLE
[Glad] Step 6 - 1 스프링 카페 7단계 - ajax 댓글 구현

### DIFF
--- a/application.yaml
+++ b/application.yaml
@@ -1,22 +1,16 @@
 spring:
-  h2:
-    console:
-      enabled: true  # H2 Console을 사용할지 여부 (H2 Console은 H2 Database를 UI로 제공해주는 기능)
-      path: /h2-console  # H2 Console의 Path
-  # Database Setting Info (Database를 H2로 사용하기 위해 H2연결 정보 입력)
   datasource:
-    driver-class-name: org.h2.Driver
-    url: 'jdbc:h2:mem:test'
-    username: sa
-    password:
+    url: jdbc:mysql://localhost:3306/codestagram?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: springuser
+    password: password
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     generate-ddl: 'true'
-    database-platform: org.hibernate.dialect.H2Dialect
+    database-platform: org.hibernate.dialect.MySQL8Dialect
     defer-datasource-initialization: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
         format_sql: true
         show_sql: true

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	// H2
-	runtimeOnly 'com.h2database:h2'
+	// MySQL
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	// JPA
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 }

--- a/deploy.sh
+++ b/deploy.sh
@@ -64,7 +64,7 @@ else
 fi
 
 # Search for the built jar file
-JAR_FILE=$(find build/libs -type f -name "*.jar" | head -n 1)
+JAR_FILE=$(find build/libs -type f -name "*.jar" ! -name "*plain.jar" | head -n 1)
 if [ -z "$JAR_FILE" ]; then
   echo "빌드된 jar 파일을 찾을 수 없습니다."
   exit 1

--- a/deploy.sh
+++ b/deploy.sh
@@ -51,6 +51,14 @@ echo "애플리케이션 빌드 중..."
 ./gradlew clean build -x test
 echo "애플리케이션 빌드 완료."
 
+# MySQL 서비스 상태 확인 및 시작
+if ! systemctl is-active --quiet mysql; then
+  echo "MySQL 서비스가 실행 중이 아닙니다. 서비스를 시작합니다..."
+  sudo systemctl start mysql
+
+  sudo systemctl enable mysql
+fi
+
 DB_EXISTS=$(sudo mysql -N -s -e "SHOW DATABASES LIKE 'codestagram';")
 if [ "$DB_EXISTS" != "codestagram" ]; then
   echo "MySQL 데이터베이스 설정을 진행합니다..."

--- a/src/main/java/codesquad/codestagram/domain/article/ArticleController.java
+++ b/src/main/java/codesquad/codestagram/domain/article/ArticleController.java
@@ -16,11 +16,9 @@ import java.util.List;
 public class ArticleController {
 
     private final ArticleService articleService;
-    private final ReplyService replyService;
 
-    public ArticleController(ArticleService articleService, ReplyService replyService) {
+    public ArticleController(ArticleService articleService) {
         this.articleService = articleService;
-        this.replyService = replyService;
     }
 
     // 게시물 생성
@@ -40,9 +38,6 @@ public class ArticleController {
                               Model model) {
         Article article = articleService.findArticle(id);
         model.addAttribute("article", article);
-
-        List<Reply> repliesByArticle = replyService.findRepliesByArticle(id);
-        model.addAttribute("replies", repliesByArticle);
 
         return "article/view";
     }

--- a/src/main/java/codesquad/codestagram/domain/reply/ReplyController.java
+++ b/src/main/java/codesquad/codestagram/domain/reply/ReplyController.java
@@ -1,6 +1,7 @@
 package codesquad.codestagram.domain.reply;
 
 import codesquad.codestagram.common.constants.SessionConstants;
+import codesquad.codestagram.domain.reply.dto.ReplyRequestDto;
 import codesquad.codestagram.domain.reply.dto.ReplyResponseDto;
 import codesquad.codestagram.domain.user.User;
 import jakarta.servlet.http.HttpSession;
@@ -31,23 +32,22 @@ public class ReplyController {
     }
 
     @PostMapping("")
-    public String addReply(@PathVariable Long articleId,
-                           @RequestParam String content,
-                           HttpSession session) {
+    public ResponseEntity<ReplyResponseDto> addReply(@PathVariable Long articleId,
+                                                     @RequestBody ReplyRequestDto replyRequestDto,
+                                                     HttpSession session) {
         User user = (User) session.getAttribute(SessionConstants.USER_SESSION_KEY);
-        replyService.addReply(articleId, user, content);
+        Reply newReply = replyService.addReply(articleId, user, replyRequestDto.content());
 
-        return "redirect:/articles/" + articleId;
+        return ResponseEntity.ok(ReplyResponseDto.of(newReply));
     }
 
     @DeleteMapping("{replyId}")
-    public String deleteReply(@PathVariable Long articleId,
-                              @PathVariable Long replyId,
-                              HttpSession session) {
+    public ResponseEntity<Void> deleteReply(@PathVariable Long replyId,
+                                            HttpSession session) {
         User user = (User) session.getAttribute(SessionConstants.USER_SESSION_KEY);
         replyService.deleteReply(replyId, user);
 
-        return "redirect:/articles/" + articleId;
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/codesquad/codestagram/domain/reply/ReplyController.java
+++ b/src/main/java/codesquad/codestagram/domain/reply/ReplyController.java
@@ -1,12 +1,16 @@
 package codesquad.codestagram.domain.reply;
 
 import codesquad.codestagram.common.constants.SessionConstants;
+import codesquad.codestagram.domain.reply.dto.ReplyResponseDto;
 import codesquad.codestagram.domain.user.User;
 import jakarta.servlet.http.HttpSession;
-import org.springframework.stereotype.Controller;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Controller
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
 @RequestMapping("/articles/{articleId}/replies")
 public class ReplyController {
 
@@ -14,6 +18,16 @@ public class ReplyController {
 
     public ReplyController(ReplyService replyService) {
         this.replyService = replyService;
+    }
+
+    @GetMapping("")
+    public ResponseEntity<List<ReplyResponseDto>> getReplies(@PathVariable Long articleId) {
+        List<ReplyResponseDto> replies = replyService.findRepliesByArticle(articleId)
+                .stream()
+                .map(ReplyResponseDto::of)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(replies);
     }
 
     @PostMapping("")

--- a/src/main/java/codesquad/codestagram/domain/reply/dto/ReplyRequestDto.java
+++ b/src/main/java/codesquad/codestagram/domain/reply/dto/ReplyRequestDto.java
@@ -1,0 +1,4 @@
+package codesquad.codestagram.domain.reply.dto;
+
+public record ReplyRequestDto(String content) {
+}

--- a/src/main/java/codesquad/codestagram/domain/reply/dto/ReplyResponseDto.java
+++ b/src/main/java/codesquad/codestagram/domain/reply/dto/ReplyResponseDto.java
@@ -1,0 +1,16 @@
+package codesquad.codestagram.domain.reply.dto;
+
+import codesquad.codestagram.domain.reply.Reply;
+
+public record ReplyResponseDto(
+        Long id,
+        String content,
+        String writerName) {
+    public static ReplyResponseDto of(Reply reply) {
+        return new ReplyResponseDto(
+                reply.getId(),
+                reply.getContent(),
+                reply.getUser().getName()
+        );
+    }
+}

--- a/src/main/resources/templates/article/view.html
+++ b/src/main/resources/templates/article/view.html
@@ -44,42 +44,22 @@
             <h4>댓글</h4>
         </div>
         <div class="card-body">
-            <div th:if="${#lists.isEmpty(replies)}">
-                <p>댓글이 없습니다.</p>
-            </div>
-            <div th:if="${!#lists.isEmpty(replies)}">
-                <ul class="list-group">
-                    <li class="list-group-item" th:each="reply : ${replies}">
-                        <div class="d-flex justify-content-between">
-                            <div>
-                                <strong th:text="${reply.user.getName()}">작성자</strong>
-<!--                                <small th:text="${#dates.format(reply.createdAt, 'yyyy-MM-dd HH:mm')}">작성일</small>-->
-                            </div>
-                            <div th:if="${session.sessionedUser.getId() == reply.user.id}">
-                                <form th:action="@{/articles/{articleId}/replies/{replyId}(articleId=${article.id}, replyId=${reply.id})}"
-                                      method="post" style="display: inline;">
-                                    <input type="hidden" name="_method" value="DELETE" />
-                                    <button type="submit" class="btn btn-sm btn-danger"
-                                            onclick="return confirm('정말 삭제하시겠습니까?')">삭제</button>
-                                </form>
-                            </div>
-                        </div>
-                        <p th:text="${reply.content}" class="mt-2 mb-0">댓글 내용</p>
-                    </li>
-                </ul>
-            </div>
+            <ul class="list-group" id="replies-container">
+                <!-- AJAX로 채워질 댓글 목록 -->
+            </ul>
         </div>
     </div>
 
-    <!-- 댓글 작성 폼 (로그인한 사용자만 접근 가능) -->
+    <!-- 댓글 작성 폼 -->
     <div class="card mt-4">
         <div class="card-header">
             <h4>댓글 작성</h4>
         </div>
         <div class="card-body">
-            <form th:action="@{/articles/{articleId}/replies(articleId=${article.id})}" method="post">
+            <form id="reply-form">
                 <div class="mb-3">
-                    <textarea name="content" class="form-control" rows="3" placeholder="댓글을 입력하세요." required></textarea>
+                    <textarea id="reply-content" class="form-control" rows="3" placeholder="댓글을 입력하세요."
+                              required></textarea>
                 </div>
                 <button type="submit" class="btn btn-primary">댓글 등록</button>
             </form>
@@ -88,5 +68,82 @@
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.6.4.min.js"></script>
 </body>
+<script th:inline="javascript">
+    const articleId = [[${article.id}]];
+    const sessionUserName = [[${session.sessionedUser != null ? session.sessionedUser.name : null}]];
+
+    $(document).ready(function () {
+        loadReplies();
+
+        $("#reply-form").on("submit", function (e) {
+            e.preventDefault();
+            const content = $("#reply-content").val().trim();
+            if (!content) return;
+
+            $.ajax({
+                type: "POST",
+                url: `/articles/${articleId}/replies`,
+                contentType: "application/json",
+                data: JSON.stringify({ content }),
+                success: function () {
+                    $("#reply-content").val('');
+                    loadReplies();
+                },
+                error: function () {
+                    alert("댓글 등록 실패");
+                }
+            });
+        });
+    });
+
+    function loadReplies() {
+        $.ajax({
+            type: "GET",
+            url: `/articles/${articleId}/replies`,
+            success: function (replies) {
+                const container = $("#replies-container");
+                if (replies.length === 0) {
+                    container.html('<li class="list-group-item">댓글이 없습니다.</li>');
+                    return;
+                }
+
+                const replyHtml = replies.map(reply => `
+                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                        <div>
+                            <strong>${reply.writerName}</strong>
+                            <p class="mt-2 mb-0">${reply.content}</p>
+                        </div>
+                        ${reply.writerName === sessionUserName ? `
+                        <button class="btn btn-danger btn-sm" onclick="deleteReply(${reply.id})">
+                            삭제
+                        </button>` : ''}
+                    </li>
+                `).join('');
+
+                container.html(replyHtml);
+            },
+            error: function () {
+                alert("댓글 불러오기 실패");
+            }
+        });
+    }
+
+    function deleteReply(replyId) {
+        if (!confirm("정말 삭제하시겠습니까?")) return;
+
+        $.ajax({
+            type: "DELETE",
+            url: `/articles/${articleId}/replies/${replyId}`,
+            success: function () {
+                loadReplies();
+            },
+            error: function () {
+                alert("댓글 삭제 실패");
+            }
+        });
+    }
+</script>
+
 </html>


### PR DESCRIPTION
## 구현 내용

- 댓글 기능 ajax 로 구현
  - `ReplyController`에서 `@RestController` 로 변경
  - `ReplyRequestDto`, `ReplyResponseDto` 추가하여 댓글 요청 및 응답 DTO 구현
  - 댓글 목록은 게시글 상세 진입 시 비동기로 조회
  - 댓글 추가 및 삭제는 Ajax (`$.ajax`) 요청을 통해 처리
  - 댓글 추가/삭제 후 `loadReplies()` 호출로 전체 댓글을 다시 렌더링
  - 삭제는 로그인된 사용자와 댓글 작성자가 일치할 경우에만 삭제 버튼 노출
  - 타임리프의 `th:inline="javascript"`를 활용해 JS 내부에서 서버 값을 사용할 수 있도록 설정

- 데이터베이스 H2 → MySQL 전환
  - 로컬 개발 및 배포 환경 모두 MySQL 8 사용하도록 변경
  - application.yaml에 MySQL 접속 설정 적용

- 배포 자동화 스크립트 수정 (`deploy.sh`)
  - docker를 사용하여 배포했던 스크립트를 직접 `./gradlew build` 후 직접 `jar` 파일을 실행해서 배포하도록 변경
  - `./gradlew build` 시에 메모리 부족으로 실패하는 경우가 있어 스왑 메모리 확보 스크립트 추가
  - Database가 H2 -> MySQL로 변경됨에 따라 mysql database 초기화 스크립트 추가

## 고민 사항

1. 댓글 API에서 `articleId` 전달 방식에 대한 설계 고민 
 현재 매핑경로가 `/articles/{articleId}/replies` 형태로 `articleId`를 URL 경로에 담아 `@PathVariable`로 전달받고 있습니다
하지만 JSON으로 주고받을 때 DTO에 `articleId`를 포함시켜 `@RequestBody`로 처리하는 것도 가능할 것 같습니다
어떤 방식이 더 명확하고 일관적인지에 대해 확신이 없었어서 URL 경로로 받아오는 `@PathVariable` 방식이 직관적이라는 판단으로 우선 적용하였습니다

## 기타

- 배포 주소: http://3.35.4.77:8080/
